### PR TITLE
Unbreak build on FreeBSD

### DIFF
--- a/src/conc/Interlocked.hpp
+++ b/src/conc/Interlocked.hpp
@@ -100,10 +100,6 @@ int32_t	Interlocked::cas (int32_t volatile &dest, int32_t excg, int32_t comp)
 		::LONG (comp)
 	));
 
-#elif defined (__linux__)
-
-	return (__sync_val_compare_and_swap (&dest, comp, excg));
-
 #elif defined (__APPLE__)
 
 	return (::OSAtomicCompareAndSwap32Barrier (
@@ -111,6 +107,10 @@ int32_t	Interlocked::cas (int32_t volatile &dest, int32_t excg, int32_t comp)
 		excg,
 		const_cast <int32_t *> (reinterpret_cast <int32_t volatile *> (&dest))
 	) ? comp : excg);
+
+#elif defined (__GNUC__)
+
+	return (__sync_val_compare_and_swap (&dest, comp, excg));
 
 #else
 
@@ -214,10 +214,6 @@ int64_t	Interlocked::cas (int64_t volatile &dest, int64_t excg, int64_t comp)
 
 	return (old);
 
-#elif defined (__linux__)
-
-	return (__sync_val_compare_and_swap (&dest, comp, excg));
-
 #elif defined (__APPLE__)
 
 	return (::OSAtomicCompareAndSwap64Barrier (
@@ -225,6 +221,10 @@ int64_t	Interlocked::cas (int64_t volatile &dest, int64_t excg, int64_t comp)
 		excg, 
 		const_cast <int64_t *> (reinterpret_cast <int64_t volatile *> (&dest))
 	) ? comp : excg);
+
+#elif defined (__GNUC__)
+
+	return (__sync_val_compare_and_swap (&dest, comp, excg));
 
 #else
 
@@ -355,9 +355,13 @@ void	Interlocked::cas (Data128 &old, volatile Data128 &dest, const Data128 &excg
 
 	#endif
 
-#elif defined (__linux__)
+#elif defined (__GNUC__)
 
 	old = __sync_val_compare_and_swap (&dest, comp, excg);
+
+#else
+
+	#error Unknown platform
 
 #endif
 }


### PR DESCRIPTION
Clang also supports `__sync*` atomics. Part of [my port](https://www.freshports.org/graphics/vapoursynth-fmtconv). Binary packages for FreeBSD 10.3/11.0/12.0 i386/amd64, DragonFly x86_64 in a few days.

Other BSDs didn't try to package VapourSynth...
