### PR TITLE
Enable building AviSynth+ plugin on non-Windows

### DIFF
--- a/build/unix/Makefile.am
+++ b/build/unix/Makefile.am
@@ -302,10 +302,20 @@ commonsrc = \
         ../../src/AvstpWrapper.h
 
 libfmtconv_la_SOURCES = $(commonsrc) \
+        ../../src/avisynth.h \
         ../../src/main-avs.cpp \
         ../../src/main-vs.cpp \
         ../../src/types.h \
         ../../src/VapourSynth4.h \
+        ../../src/avs/alignment.h \
+        ../../src/avs/capi.h \
+        ../../src/avs/config.h \
+        ../../src/avs/cpuid.h \
+        ../../src/avs/filesystem.h \
+        ../../src/avs/minmax.h \
+        ../../src/avs/posix.h \
+        ../../src/avs/types.h \
+        ../../src/avs/win.h \
         ../../src/fmtc/Bitdepth_vs.cpp \
         ../../src/fmtc/Bitdepth.h \
         ../../src/fmtc/Convert.cpp \

--- a/build/unix/Makefile.am
+++ b/build/unix/Makefile.am
@@ -302,6 +302,7 @@ commonsrc = \
         ../../src/AvstpWrapper.h
 
 libfmtconv_la_SOURCES = $(commonsrc) \
+        ../../src/main-avs.cpp \
         ../../src/main-vs.cpp \
         ../../src/types.h \
         ../../src/VapourSynth4.h \
@@ -330,6 +331,40 @@ libfmtconv_la_SOURCES = $(commonsrc) \
         ../../src/fmtc/Transfer_vs.cpp \
         ../../src/fmtc/Transfer.h \
         ../../src/fmtc/version.h \
+        ../../src/fmtcavs/Bitdepth_avs.cpp \
+        ../../src/fmtcavs/Bitdepth.h \
+        ../../src/fmtcavs/CpuOpt_avs.cpp \
+        ../../src/fmtcavs/CpuOpt.h \
+        ../../src/fmtcavs/FmtAvs.cpp \
+        ../../src/fmtcavs/FmtAvs.h \
+        ../../src/fmtcavs/fnc_fmtcavs.cpp \
+        ../../src/fmtcavs/fnc.h \
+        ../../src/fmtcavs/function_names.h \
+        ../../src/fmtcavs/Matrix2020CL_avs.cpp \
+        ../../src/fmtcavs/Matrix2020CL.h \
+        ../../src/fmtcavs/Matrix_avs.cpp \
+        ../../src/fmtcavs/Matrix.h \
+        ../../src/fmtcavs/Primaries_avs.cpp \
+        ../../src/fmtcavs/Primaries.h \
+        ../../src/fmtcavs/ProcAlpha.cpp \
+        ../../src/fmtcavs/ProcAlpha.h \
+        ../../src/fmtcavs/Resample_avs.cpp \
+        ../../src/fmtcavs/Resample.h \
+        ../../src/fmtcavs/Transfer_avs.cpp \
+        ../../src/fmtcavs/Transfer.h \
+        ../../src/avsutl/CsPlane.cpp \
+        ../../src/avsutl/CsPlane.h \
+        ../../src/avsutl/fnc_avsutl.cpp \
+        ../../src/avsutl/fnc.h \
+        ../../src/avsutl/fnc.hpp \
+        ../../src/avsutl/PlaneProcCbInterface_avs.cpp \
+        ../../src/avsutl/PlaneProcCbInterface.h \
+        ../../src/avsutl/PlaneProcessor_avs.cpp \
+        ../../src/avsutl/PlaneProcessor.h \
+        ../../src/avsutl/PlaneProcMode.h \
+        ../../src/avsutl/TFlag.h \
+        ../../src/avsutl/VideoFilterBase.cpp \
+        ../../src/avsutl/VideoFilterBase.h \
         ../../src/vsutl/FilterBase.cpp \
         ../../src/vsutl/FilterBase.h \
         ../../src/vsutl/fnc_vsutl.cpp \

--- a/src/main-avs.cpp
+++ b/src/main-avs.cpp
@@ -1,7 +1,8 @@
-
+#if defined (_WIN32)
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
 #define NOGDI
+#endif
 
 #include "avsutl/fnc.h"
 #include "fmtcavs/Bitdepth.h"
@@ -13,13 +14,24 @@
 #include "fmtcavs/Transfer.h"
 #include "fstb/def.h"
 
+#if defined (_WIN32)
 #include <windows.h>
+#else
+#include "avs/posix.h"
+#endif
 #include "avisynth.h"
 
 #if defined (_MSC_VER) && ! defined (NDEBUG) && defined (_DEBUG)
 	#include	<crtdbg.h>
 #endif
 
+#if defined (_WIN32)
+	#define AVS_EXPORT __declspec(dllexport)
+#elif defined(__GNUC__) && __GNUC__ >= 4
+	#define AVS_EXPORT __attribute__((visibility("default")))
+#else
+	#define AVS_EXPORT
+#endif
 
 
 template <class T>
@@ -34,7 +46,7 @@ template <class T>
 
 const ::AVS_Linkage *	AVS_linkage = nullptr;
 
-extern "C" __declspec (dllexport)
+extern "C" AVS_EXPORT
 const char * __stdcall	AvisynthPluginInit3 (::IScriptEnvironment *env_ptr, const ::AVS_Linkage * const vectors_ptr)
 {
 	AVS_linkage = vectors_ptr;
@@ -95,7 +107,7 @@ const char * __stdcall	AvisynthPluginInit3 (::IScriptEnvironment *env_ptr, const
 }
 
 
-
+#if defined (_WIN32)
 static void	main_avs_dll_load (::HINSTANCE hinst)
 {
 	fstb::unused (hinst);
@@ -157,3 +169,4 @@ BOOL WINAPI DllMain (::HINSTANCE hinst, ::DWORD reason, ::LPVOID reserved_ptr)
 
 	return TRUE;
 }
+#endif


### PR DESCRIPTION
Possible to-do: hook in pkgconfig so that autotools won't fail if only one of either VapourSynth or AviSynth+ is present.