### PR TITLE
Doc: fix typo

### DIFF
--- a/doc/fmtconv.html
+++ b/doc/fmtconv.html
@@ -1292,7 +1292,7 @@ between the sampling points.</li>
 <p>Clip to be resized. Mandatory.
 Supported input formats:</p>
 <ul>
-<li>8-, 9-, 10-, 12-, 16- and 16-bit integer.</li>
+<li>8-, 9-, 10-, 12-, 14- and 16-bit integer.</li>
 <li>32-bit floating point.</li>
 <li>Any planar colorspace.</li>
 </ul>


### PR DESCRIPTION
14-bit integer is mislabeled and was why I thought #38 was due to an unsupported input depth.