### PR TITLE
BitBltConv.cpp: fix duplicated conversion in `bitblt_int_to_flt_cpp`.

### DIFF
--- a/src/fmtcl/BitBltConv.cpp
+++ b/src/fmtcl/BitBltConv.cpp
@@ -409,7 +409,7 @@ void	BitBltConv::bitblt_int_to_flt_cpp (uint8_t *dst_ptr, ptrdiff_t dst_stride, 
 			{
 				val = val * gain + add_cst;
 			}
-			dst_flt_ptr [x] = float (val) * gain + add_cst;
+			dst_flt_ptr [x] = val;
 
 			SRC::PtrConst::jump (cur_src_ptr, 1);
 		}


### PR DESCRIPTION
For CPUs without SSE or AVX, e.g. Apple M1, `bitblt_int_to_flt_cpp` will be called if int to float conversion is applied. `fmtconv` will give a wrong result because of the duplicated `val * gain + add_cst`.